### PR TITLE
Add pytest dependency and fix imports for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psycopg2-binary==2.9.3
 Werkzeug==2.1.1
 marshmallow
 marshmallow-SQLAlchemy
+pytest>=7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
 # tests/conftest.py
+import os
+import sys
 import pytest
+
+# Ensure the app package is importable when tests are run without installation
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from app import create_app, db as _db
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
## Summary
- add `pytest` dependency to `requirements.txt`
- adjust `tests/conftest.py` to include repo root in Python path

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q` *(fails: 14 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687fd91e25b4832e9073795eda29b5fc