### PR TITLE
Fix JWT identity type and update routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 *.pyc
 .env
 .DS_Store
+
+venv/

--- a/app/events/routes.py
+++ b/app/events/routes.py
@@ -33,7 +33,7 @@ def get_event(event_id: int):
 def create_event():
     """Create a new event owned by the current user."""
     data = request.get_json() or {}
-    user_id = get_jwt_identity()
+    user_id = int(get_jwt_identity())
     event = EventService.create_event(user_id, data)
     return jsonify(event_schema.dump(event)), 201
 
@@ -41,7 +41,7 @@ def create_event():
 @jwt_required()
 def update_event(event_id: int):
     """Update an existing event if owned by user."""
-    user_id = get_jwt_identity()
+    user_id = int(get_jwt_identity())
     data = request.get_json() or {}
     event = EventService.update_event(event_id, user_id, data)
     return jsonify(event_schema.dump(event)), 200
@@ -50,6 +50,6 @@ def update_event(event_id: int):
 @jwt_required()
 def delete_event(event_id: int):
     """Delete an event if owned by user."""
-    user_id = get_jwt_identity()
+    user_id = int(get_jwt_identity())
     EventService.delete_event(event_id, user_id)
     return jsonify({'message': 'Event deleted'}), 200

--- a/app/registrations/routes.py
+++ b/app/registrations/routes.py
@@ -12,7 +12,7 @@ regs_schema = RegistrationSchema(many=True)
 @jwt_required()
 def register_event(event_id: int):
     """RSVP current user to an event."""
-    user_id = get_jwt_identity()
+    user_id = int(get_jwt_identity())
     reg = RegistrationService.register_for_event(user_id, event_id)
     return jsonify(reg_schema.dump(reg)), 201
 
@@ -20,7 +20,7 @@ def register_event(event_id: int):
 @jwt_required()
 def cancel_registration(registration_id: int):
     """Cancel a registration."""
-    user_id = get_jwt_identity()
+    user_id = int(get_jwt_identity())
     RegistrationService.cancel_registration(registration_id, user_id)
     return jsonify({'message': 'Registration canceled'}), 200
 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -34,7 +34,7 @@ class UserService:
         user = User.query.filter_by(email=email).first()
         if not user or not check_password_hash(user.password_hash, password):
             raise AuthenticationError('Invalid credentials')
-        token = create_access_token(identity=user.id)
+        token = create_access_token(identity=str(user.id))
         return token
 
     @staticmethod


### PR DESCRIPTION
## Summary
- ensure JWT tokens use a string identity
- convert identities from JWT to integers in event and registration routes
- ignore local venv in `.gitignore`

## Testing
- `venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd87c9fb4832e92731dd0cd3ca5ba