### PR TITLE
Switch to Google OAuth with bcrypt passwords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ JWT_SECRET_KEY=changeme
 DATABASE_URL=postgresql://appuser:secret@db:5432/appdb
 FLASK_ENV=development
 FLASK_DEBUG=1
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple Flask application for creating and attending events.
 
 ## Features
 
-- User registration and JWT-based login
+- Google OAuth login with JWT tokens for the API
 - Create, update and delete your own events
 - RSVP to events created by others
 - Search and pagination on the events list
@@ -15,7 +15,7 @@ A simple Flask application for creating and attending events.
 ## Security Highlights
 
 - Secrets such as `SECRET_KEY` and database credentials come from environment
-  variables loaded via `.env`
+  variables loaded via `.env` (including Google OAuth credentials)
 - SQLAlchemy parameter binding guards against SQL injection
 - Ownership checks before update/delete prevent IDOR issues
 - Flask-Talisman sets a basic Content-Security-Policy
@@ -48,6 +48,12 @@ docker compose up --build
 
 The service listens on port 5000. Visit `http://localhost:5000` to use the app.
 API endpoints live under `/api`.
+
+### Google OAuth Setup
+
+Populate `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in your `.env` file with
+credentials from the Google developer console. The OAuth callback URL should be
+`http://localhost:5000/callback`.
 
 ## Running Tests
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_jwt_extended import JWTManager
 from flask_talisman import Talisman
+from authlib.integrations.flask_client import OAuth
 from app.exceptions import (
     UserValidationError,
     AuthenticationError,
@@ -15,6 +16,7 @@ talisman = Talisman()
 db = SQLAlchemy()
 migrate = Migrate()
 jwt = JWTManager()
+oauth = OAuth()
 
 
 def create_app(config: dict = None) -> Flask:
@@ -41,6 +43,14 @@ def create_app(config: dict = None) -> Flask:
 
     migrate.init_app(app, db)
     jwt.init_app(app)
+    oauth.init_app(app)
+    oauth.register(
+        name='google',
+        client_id=os.getenv('GOOGLE_CLIENT_ID'),
+        client_secret=os.getenv('GOOGLE_CLIENT_SECRET'),
+        server_metadata_url='https://accounts.google.com/.well-known/openid-configuration',
+        client_kwargs={'scope': 'openid email profile'}
+    )
     talisman.init_app(
         app,
         force_https=False,
@@ -76,12 +86,14 @@ def create_app(config: dict = None) -> Flask:
     from app.home import home_bp
     from app.registrations.routes import registrations_bp
     from app.frontend.routes import frontend_bp
+    from app.oauth import oauth_bp
 
     app.register_blueprint(users_bp)
     app.register_blueprint(events_bp)
     app.register_blueprint(home_bp)
     app.register_blueprint(registrations_bp)
     app.register_blueprint(frontend_bp)
+    app.register_blueprint(oauth_bp)
 
 
 

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -1,0 +1,27 @@
+from flask import Blueprint, url_for, redirect, render_template
+from flask_jwt_extended import create_access_token
+from app import oauth, db
+from app.models import User
+
+oauth_bp = Blueprint('oauth', __name__)
+
+@oauth_bp.route('/login/google')
+def login_google():
+    redirect_uri = url_for('oauth.authorize', _external=True)
+    return oauth.google.authorize_redirect(redirect_uri)
+
+@oauth_bp.route('/callback')
+def authorize():
+    token = oauth.google.authorize_access_token()
+    resp = oauth.google.get('userinfo', token=token)
+    user_info = resp.json()
+    email = user_info.get('email')
+    username = user_info.get('name') or email.split('@')[0]
+    user = User.query.filter_by(email=email).first()
+    if not user:
+        user = User(username=username, email=email, password_hash='')
+        db.session.add(user)
+        db.session.commit()
+    jwt_token = create_access_token(identity=str(user.id))
+    return render_template('oauth_callback.html', token=jwt_token)
+

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,4 +1,4 @@
-from werkzeug.security import generate_password_hash, check_password_hash
+import bcrypt
 from flask_jwt_extended import create_access_token
 from app.models import User
 from app import db
@@ -19,7 +19,7 @@ class UserService:
         if User.query.filter((User.username == username) | (User.email == email)).first():
             raise UserValidationError('User with that username or email already exists')
         # SQLAlchemy parameter binding thwarts SQL injection
-        password_hash = generate_password_hash(password)
+        password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
         new_user = User(username=username, email=email, password_hash=password_hash)
         db.session.add(new_user)
         db.session.commit()
@@ -31,7 +31,7 @@ class UserService:
         if not email or not password:
             raise AuthenticationError('Email and password are required')
         user = User.query.filter_by(email=email).first()
-        if not user or not check_password_hash(user.password_hash, password):
+        if not user or not bcrypt.checkpw(password.encode(), user.password_hash.encode()):
             raise AuthenticationError('Invalid credentials')
         token = create_access_token(identity=str(user.id))
         return token

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -39,7 +39,8 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (path === "/register") {
-    document.getElementById("register-form").onsubmit = async (e) => {
+    const form = document.getElementById("register-form");
+    if (form) form.onsubmit = async (e) => {
       e.preventDefault();
       const f = e.target;
       const res = await fetch(API_BASE + "/users/register", {
@@ -60,7 +61,8 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (path === "/login") {
-    document.getElementById("login-form").onsubmit = async (e) => {
+    const form = document.getElementById("login-form");
+    if (form) form.onsubmit = async (e) => {
       e.preventDefault();
       const f = e.target;
       const res = await fetch(API_BASE + "/users/login", {

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,14 +1,5 @@
-{% extends "base.html" %} {% block content %}
+{% extends "base.html" %}
+{% block content %}
 <h2>Login</h2>
-<form id="login-form">
-  <div class="form-group">
-    <label>Email</label>
-    <input type="email" name="email" class="form-control" required />
-  </div>
-  <div class="form-group">
-    <label>Password</label>
-    <input type="password" name="password" class="form-control" required />
-  </div>
-  <button type="submit" class="btn btn-primary">Login</button>
-</form>
+<a href="/login/google" class="btn btn-primary">Sign in with Google</a>
 {% endblock %}

--- a/app/templates/oauth_callback.html
+++ b/app/templates/oauth_callback.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<p>Login successful. Redirecting...</p>
+<script>
+localStorage.setItem('jwt', '{{ token }}');
+window.location = '/events';
+</script>
+{% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,18 +1,6 @@
-{% extends "base.html" %} {% block content %}
+{% extends "base.html" %}
+{% block content %}
 <h2>Register</h2>
-<form id="register-form">
-  <div class="form-group">
-    <label>Username</label>
-    <input type="text" name="username" class="form-control" required />
-  </div>
-  <div class="form-group">
-    <label>Email</label>
-    <input type="email" name="email" class="form-control" required />
-  </div>
-  <div class="form-group">
-    <label>Password</label>
-    <input type="password" name="password" class="form-control" required />
-  </div>
-  <button type="submit" class="btn btn-primary">Register</button>
-</form>
+<p>Use Google to sign in.</p>
+<a href="/login/google" class="btn btn-primary">Sign in with Google</a>
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ marshmallow
 marshmallow-SQLAlchemy
 pytest>=7.0
 Flask-Talisman==1.1.0
+bcrypt
+Authlib
+requests


### PR DESCRIPTION
## Summary
- integrate Google OAuth using authlib
- hash passwords with bcrypt instead of Werkzeug's defaults
- add OAuth callback handler and template
- update login and register pages to use Google sign‑in
- document new OAuth setup

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688250fd77fc832e94882e2bb973c3ea